### PR TITLE
Improvement/#20774 Make source names shorter in incidents and assets

### DIFF
--- a/lib/logstash/filters/incident_enrichment.rb
+++ b/lib/logstash/filters/incident_enrichment.rb
@@ -164,11 +164,11 @@ class LogStash::Filters::IncidentEnrichment < LogStash::Filters::Base
     }
 
     if @incidents_priority_filter
-      if @source == 'redBorder Intrusion'
+      if @source == 'Intrusion'
         if intrusion_priority_map.key?(priority.to_sym) && intrusion_priority_map.key?(@incidents_priority_filter.to_sym)
           return intrusion_priority_map[priority.to_sym] >= intrusion_priority_map[@incidents_priority_filter.to_sym]
         end
-      elsif @source == 'redBorder Vault'
+      elsif @source == 'Vault'
         if vault_priority_map.key?(priority.to_sym) && vault_priority_map.key?(@incidents_priority_filter.to_sym)
           return vault_priority_map[priority.to_sym] >= vault_priority_map[@incidents_priority_filter.to_sym]
         end

--- a/logstash-filter-incident-enrichment.gemspec
+++ b/logstash-filter-incident-enrichment.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-incident-enrichment'
-  s.version = '0.0.6'
+  s.version = '0.0.7'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This filter is part of the redBorder enrich system. Create incidents into a cache, keep track of the relevant event fields and enrich the event when necessary."
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/20774)

## Description

Rename from `redBorder Intrusion` and `redBorder Vault` to `Intrusion` and `Vault`.