### PR TITLE
Bugfix/#22068 Can't convert String into an exact number in get_timestamp

### DIFF
--- a/lib/logstash/filters/incident_enrichment.rb
+++ b/lib/logstash/filters/incident_enrichment.rb
@@ -125,9 +125,19 @@ class LogStash::Filters::IncidentEnrichment < LogStash::Filters::Base
 
   def get_timestamp(event)
     timestamp = event.get(TIMESTAMP)
-    return nil unless timestamp
+    return Time.now unless timestamp
 
-    Time.at(timestamp)
+    # Integer conversion
+    begin
+      return Time.at(Integer(timestamp))
+    rescue ArgumentError, TypeError
+      # Not an integer. Parsing ISO8601 string
+      begin
+        return Time.parse(timestamp)
+      rescue ArgumentError, TypeError
+        return Time.now
+      end
+    end
   end
 
   def save_incident(prefix, incident)

--- a/logstash-filter-incident-enrichment.gemspec
+++ b/logstash-filter-incident-enrichment.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-incident-enrichment'
-  s.version = '0.0.8'
+  s.version = '0.0.9'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This filter is part of the redBorder enrich system. Create incidents into a cache, keep track of the relevant event fields and enrich the event when necessary."
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/22068)

## Description

`get_timestamp` method supports:

- Epoch numbers in string or integer (e.g. "1727934182", 1727934182)
- ISO8601 dates ("2025-07-02T07:41:38Z")