### PR TITLE
Improvement #24091 Change Uknown incident name in Vault incidents

### DIFF
--- a/lib/logstash/filters/incident_enrichment.rb
+++ b/lib/logstash/filters/incident_enrichment.rb
@@ -141,7 +141,7 @@ class LogStash::Filters::IncidentEnrichment < LogStash::Filters::Base
     when 'Vault'
       "Syslog incident from sensor #{event.get('sensor_name')}"
     else
-      event.get(MSG) || 'Syslog incident from sensor '
+      event.get(MSG) || 'Unknown incident'
     end
   end
 

--- a/lib/logstash/filters/incident_enrichment.rb
+++ b/lib/logstash/filters/incident_enrichment.rb
@@ -135,10 +135,13 @@ class LogStash::Filters::IncidentEnrichment < LogStash::Filters::Base
   end
 
   def get_name(event)
-    if @source == 'Malware'
+    case @source
+    when 'Malware'
       "Malware detected in #{event.get('file_name') || 'unknown file'}"
+    when 'Vault'
+      "Syslog incident from sensor #{event.get('sensor_name')}"
     else
-      event.get(MSG) || 'Unknown incident'
+      event.get(MSG) || 'Syslog incident from sensor '
     end
   end
 

--- a/logstash-filter-incident-enrichment.gemspec
+++ b/logstash-filter-incident-enrichment.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-incident-enrichment'
-  s.version = '1.1.0'
+  s.version = '1.2.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This filter is part of the redBorder enrich system. Create incidents into a cache, keep track of the relevant event fields and enrich the event when necessary."
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
#### Related issue in RedMine

Redmine [Activity #24091](https://redmine.redborder.lan/issues/24091)

#### Description / Motivation

Update 'Unknown incident' in Vault-generated incidents to a more descriptive name.